### PR TITLE
migrate from js-cookie to localStorage + related changes

### DIFF
--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -38,7 +38,7 @@ function AuthProvider(props: AuthProviderProps) {
 
   useEffect(() => {
     const loadAuthStateFromStorage = () => {
-      const storedAuthState: LoggedInState | undefined = JSONLocalStorage?.get(
+      const storedAuthState: LoggedInState | undefined = JSONLocalStorage.get(
         LOCAL_STORAGE_AUTH_KEY
       );
       const tokenNotExpired = storedAuthState?.expiresAt
@@ -58,14 +58,14 @@ function AuthProvider(props: AuthProviderProps) {
 
   const logIn = useCallback(async (loggedInState: LoggedInState) => {
     if (loggedInState) {
-      JSONLocalStorage?.set(LOCAL_STORAGE_AUTH_KEY, loggedInState);
+      JSONLocalStorage.set(LOCAL_STORAGE_AUTH_KEY, loggedInState);
       setUserEmail(loggedInState.profileData?.email || null);
       setIsAuthenticated(true);
     }
   }, []);
 
   const logOut = useCallback(() => {
-    JSONLocalStorage?.clear();
+    JSONLocalStorage.clear();
     setUserEmail(null);
     setIsAuthenticated(false);
   }, []);
@@ -77,7 +77,7 @@ function AuthProvider(props: AuthProviderProps) {
         logOut();
       }
     };
-
+    // make sure Next.js is running on client-side (window is defined), before attempting to add window listeners
     if (typeof window !== 'undefined') {
       window.addEventListener('message', onWindowMessageEvent);
       return () => window.removeEventListener('message', onWindowMessageEvent);

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -6,11 +6,13 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { getUnixTime, parseISO } from 'date-fns';
-import Cookies from 'js-cookie';
-import jwt_decode from 'jwt-decode';
+import { isPast, parseISO } from 'date-fns';
 import { LoggedInState } from '@/types';
-import api from '@/lib/api';
+import {
+  LOCAL_STORAGE_AUTH_KEY,
+  REQUEST_NOT_AUTHORIZED,
+} from '@/lib/constants';
+import { JSONLocalStorage } from '@/lib/utils/JSONStorage';
 
 interface AuthContextProps {
   isAuthenticated: boolean;
@@ -35,42 +37,52 @@ function AuthProvider(props: AuthProviderProps) {
   const [isLoading, setLoading] = useState(true);
 
   useEffect(() => {
-    const loadTokenFromCookie = () => {
-      const token = Cookies.get('idToken');
+    const loadAuthStateFromStorage = () => {
+      const storedAuthState: LoggedInState | undefined = JSONLocalStorage?.get(
+        LOCAL_STORAGE_AUTH_KEY
+      );
+      const tokenNotExpired = storedAuthState?.expiresAt
+        ? !isPast(parseISO(storedAuthState.expiresAt))
+        : false;
 
-      if (token && token !== 'undefined') {
-        // api.client.defaults.headers.Authorization = `Bearer ${token}`;
-        const { email }: { email: string | undefined } = jwt_decode(token);
-        setUserEmail(email || null);
+      if (storedAuthState && tokenNotExpired) {
+        setUserEmail(storedAuthState.profileData?.email || null);
         setIsAuthenticated(true);
       }
 
       setLoading(false);
     };
 
-    loadTokenFromCookie();
+    loadAuthStateFromStorage();
   }, []);
 
   const logIn = useCallback(async (loggedInState: LoggedInState) => {
     if (loggedInState) {
-      Cookies.set('idToken', loggedInState.idToken, {
-        expires: getUnixTime(parseISO(loggedInState.expiresAt)),
-      });
-      const { email }: { email: string | undefined } = jwt_decode(
-        loggedInState.idToken
-      );
-      // api.defaults.headers.Authorization = `Bearer ${token.token}`;
-      setUserEmail(email || null);
+      JSONLocalStorage?.set(LOCAL_STORAGE_AUTH_KEY, loggedInState);
+      setUserEmail(loggedInState.profileData?.email || null);
       setIsAuthenticated(true);
     }
   }, []);
 
   const logOut = useCallback(() => {
-    Cookies.remove('idToken');
-    // delete api.client.defaults.headers.Authorization;
+    JSONLocalStorage?.clear();
     setUserEmail(null);
     setIsAuthenticated(false);
   }, []);
+
+  useEffect(() => {
+    const onWindowMessageEvent = (event: MessageEvent) => {
+      if (event.data === REQUEST_NOT_AUTHORIZED) {
+        alert('Your session has expired, please authenticate to continue.');
+        logOut();
+      }
+    };
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('message', onWindowMessageEvent);
+      return () => window.removeEventListener('message', onWindowMessageEvent);
+    }
+  }, [logOut]);
 
   return (
     <AuthContext.Provider

--- a/lib/api/api-client.ts
+++ b/lib/api/api-client.ts
@@ -19,7 +19,7 @@ const DATA_URLS = [
 apiClient.interceptors.request.use(config => {
   if (config.url !== undefined && config.headers !== undefined) {
     if (DATA_URLS.includes(config.url)) {
-      const idToken = JSONLocalStorage?.get(LOCAL_STORAGE_AUTH_KEY).idToken;
+      const idToken = JSONLocalStorage.get(LOCAL_STORAGE_AUTH_KEY).idToken;
       config.headers.Authorization = idToken ? `Bearer ${idToken}` : '';
     }
   }
@@ -30,7 +30,7 @@ apiClient.interceptors.request.use(config => {
 apiClient.interceptors.response.use(
   response => response,
   error => {
-    const storedAuthState = JSONLocalStorage?.get(LOCAL_STORAGE_AUTH_KEY);
+    const storedAuthState = JSONLocalStorage.get(LOCAL_STORAGE_AUTH_KEY);
     const hasExpired = storedAuthState?.expiresAt
       ? isPast(parseISO(storedAuthState.expiresAt))
       : false;

--- a/lib/api/services/auth.ts
+++ b/lib/api/services/auth.ts
@@ -1,12 +1,16 @@
-import Cookies from 'js-cookie';
 import { LoggedInState } from '@/types';
+import {
+  LOCAL_STORAGE_AUTH_KEY,
+  LOCAL_STORAGE_REDIRECT_KEY,
+} from '@/lib/constants';
 import { generateAppContextHash } from '@/lib/utils';
+import { JSONLocalStorage } from '@/lib/utils/JSONStorage';
 import apiClient from '../api-client';
 import { AUTH_GW_BASE_URL } from '../endpoints';
 
 export function directToAuthGwLogin(redirectPath?: string) {
   if (redirectPath) {
-    localStorage.setItem('redirectPath', redirectPath);
+    JSONLocalStorage?.set(LOCAL_STORAGE_REDIRECT_KEY, redirectPath);
   }
 
   window.location.assign(
@@ -15,9 +19,8 @@ export function directToAuthGwLogin(redirectPath?: string) {
 }
 
 export function directToAuthGwLogout() {
-  const idToken = Cookies.get('idToken');
-  Cookies.remove('idToken');
-  localStorage.removeItem('redirectPath');
+  const idToken = JSONLocalStorage?.get(LOCAL_STORAGE_AUTH_KEY).idToken;
+  JSONLocalStorage?.clear();
 
   window.location.assign(
     `${AUTH_GW_BASE_URL}/auth/openid/testbed/logout-request?appContext=${generateAppContextHash()}&idToken=${idToken}`

--- a/lib/api/services/auth.ts
+++ b/lib/api/services/auth.ts
@@ -10,7 +10,7 @@ import { AUTH_GW_BASE_URL } from '../endpoints';
 
 export function directToAuthGwLogin(redirectPath?: string) {
   if (redirectPath) {
-    JSONLocalStorage?.set(LOCAL_STORAGE_REDIRECT_KEY, redirectPath);
+    JSONLocalStorage.set(LOCAL_STORAGE_REDIRECT_KEY, redirectPath);
   }
 
   window.location.assign(
@@ -19,8 +19,8 @@ export function directToAuthGwLogin(redirectPath?: string) {
 }
 
 export function directToAuthGwLogout() {
-  const idToken = JSONLocalStorage?.get(LOCAL_STORAGE_AUTH_KEY).idToken;
-  JSONLocalStorage?.clear();
+  const idToken = JSONLocalStorage.get(LOCAL_STORAGE_AUTH_KEY).idToken;
+  JSONLocalStorage.clear();
 
   window.location.assign(
     `${AUTH_GW_BASE_URL}/auth/openid/testbed/logout-request?appContext=${generateAppContextHash()}&idToken=${idToken}`

--- a/lib/api/services/company.ts
+++ b/lib/api/services/company.ts
@@ -1,10 +1,11 @@
-import Cookies from 'js-cookie';
 import jwt_decode from 'jwt-decode';
 import type {
   BenecifialOwners,
   NonListedCompany,
   SignatoryRights,
 } from '@/types';
+import { LOCAL_STORAGE_AUTH_KEY } from '@/lib/constants';
+import { JSONLocalStorage } from '@/lib/utils/JSONStorage';
 import apiClient from '../api-client';
 import { PRH_MOCK_BASE_URL, TESTBED_API_BASE_URL } from '../endpoints';
 
@@ -13,39 +14,38 @@ interface CompanyResponse {
   data: NonListedCompany;
 }
 
-export async function getCompanies(): Promise<CompanyResponse[]> {
-  const token = Cookies.get('idToken');
+function getUserIdentifier() {
+  const token = JSONLocalStorage?.get(LOCAL_STORAGE_AUTH_KEY).idToken;
 
   if (!token) {
     throw new Error('No token.');
   }
 
+  const { sub }: { sub: string | undefined } = jwt_decode(token);
+  return sub;
+}
+
+export async function getCompanies(): Promise<CompanyResponse[]> {
   try {
-    const { sub }: { sub: string | undefined } = jwt_decode(token);
+    const userId = getUserIdentifier();
     const { data } = await apiClient.get(
-      `${PRH_MOCK_BASE_URL}/users/${sub}/companies`
+      `${PRH_MOCK_BASE_URL}/users/${userId}/companies`
     );
     return data;
   } catch (error) {
-    throw new Error('Invalid token.');
+    throw error;
   }
 }
 
 export async function getLatestModifiedCompany(): Promise<CompanyResponse> {
-  const token = Cookies.get('idToken');
-
-  if (!token) {
-    throw new Error('No token.');
-  }
-
   try {
-    const { sub }: { sub: string | undefined } = jwt_decode(token);
+    const userId = getUserIdentifier();
     const { data } = await apiClient.get(
-      `${PRH_MOCK_BASE_URL}/users/${sub}/companies:last-modified`
+      `${PRH_MOCK_BASE_URL}/users/${userId}/companies:last-modified`
     );
     return data;
   } catch (error) {
-    throw new Error('Invalid token.');
+    throw error;
   }
 }
 
@@ -63,21 +63,15 @@ export async function getCompany(
 export async function createCompanyDirectlyToPRH(
   company: NonListedCompany
 ): Promise<string> {
-  const token = Cookies.get('idToken');
-
-  if (!token) {
-    throw new Error('No token.');
-  }
-
   try {
-    const { sub }: { sub: string | undefined } = jwt_decode(token);
+    const userId = getUserIdentifier();
     const { data } = await apiClient.post(
-      `${PRH_MOCK_BASE_URL}/users/${sub}/companies`,
+      `${PRH_MOCK_BASE_URL}/users/${userId}/companies`,
       company
     );
     return data;
   } catch (error) {
-    throw new Error('Invalid token.');
+    throw error;
   }
 }
 
@@ -85,21 +79,15 @@ export async function saveCompanyDirectlyToPRH(
   nationalIdentifier: string,
   payload: Partial<NonListedCompany>
 ) {
-  const token = Cookies.get('idToken');
-
-  if (!token) {
-    throw new Error('No token.');
-  }
-
   try {
-    const { sub }: { sub: string | undefined } = jwt_decode(token);
+    const userId = getUserIdentifier();
     const { data } = await apiClient.patch(
-      `${PRH_MOCK_BASE_URL}/users/${sub}/companies/${nationalIdentifier}`,
+      `${PRH_MOCK_BASE_URL}/users/${userId}/companies/${nationalIdentifier}`,
       payload
     );
     return data;
   } catch (error) {
-    throw new Error('Invalid token.');
+    throw error;
   }
 }
 

--- a/lib/api/services/company.ts
+++ b/lib/api/services/company.ts
@@ -15,7 +15,7 @@ interface CompanyResponse {
 }
 
 function getUserIdentifier() {
-  const token = JSONLocalStorage?.get(LOCAL_STORAGE_AUTH_KEY).idToken;
+  const token = JSONLocalStorage.get(LOCAL_STORAGE_AUTH_KEY).idToken;
 
   if (!token) {
     throw new Error('No token.');
@@ -26,27 +26,19 @@ function getUserIdentifier() {
 }
 
 export async function getCompanies(): Promise<CompanyResponse[]> {
-  try {
-    const userId = getUserIdentifier();
-    const { data } = await apiClient.get(
-      `${PRH_MOCK_BASE_URL}/users/${userId}/companies`
-    );
-    return data;
-  } catch (error) {
-    throw error;
-  }
+  const userId = getUserIdentifier();
+  const { data } = await apiClient.get(
+    `${PRH_MOCK_BASE_URL}/users/${userId}/companies`
+  );
+  return data;
 }
 
 export async function getLatestModifiedCompany(): Promise<CompanyResponse> {
-  try {
-    const userId = getUserIdentifier();
-    const { data } = await apiClient.get(
-      `${PRH_MOCK_BASE_URL}/users/${userId}/companies:last-modified`
-    );
-    return data;
-  } catch (error) {
-    throw error;
-  }
+  const userId = getUserIdentifier();
+  const { data } = await apiClient.get(
+    `${PRH_MOCK_BASE_URL}/users/${userId}/companies:last-modified`
+  );
+  return data;
 }
 
 export async function getCompany(
@@ -63,32 +55,24 @@ export async function getCompany(
 export async function createCompanyDirectlyToPRH(
   company: NonListedCompany
 ): Promise<string> {
-  try {
-    const userId = getUserIdentifier();
-    const { data } = await apiClient.post(
-      `${PRH_MOCK_BASE_URL}/users/${userId}/companies`,
-      company
-    );
-    return data;
-  } catch (error) {
-    throw error;
-  }
+  const userId = getUserIdentifier();
+  const { data } = await apiClient.post(
+    `${PRH_MOCK_BASE_URL}/users/${userId}/companies`,
+    company
+  );
+  return data;
 }
 
 export async function saveCompanyDirectlyToPRH(
   nationalIdentifier: string,
   payload: Partial<NonListedCompany>
 ) {
-  try {
-    const userId = getUserIdentifier();
-    const { data } = await apiClient.patch(
-      `${PRH_MOCK_BASE_URL}/users/${userId}/companies/${nationalIdentifier}`,
-      payload
-    );
-    return data;
-  } catch (error) {
-    throw error;
-  }
+  const userId = getUserIdentifier();
+  const { data } = await apiClient.patch(
+    `${PRH_MOCK_BASE_URL}/users/${userId}/companies/${nationalIdentifier}`,
+    payload
+  );
+  return data;
 }
 
 export async function saveCompany(

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -5,6 +5,11 @@ export const baseAppContextObj: AppContextObj = {
   redirectUrl: '',
 };
 
+export const LOCAL_STORAGE_AUTH_KEY = 'virtual-finland-auth';
+export const LOCAL_STORAGE_REDIRECT_KEY = 'redirect-path';
+
+export const REQUEST_NOT_AUTHORIZED = 'rna';
+
 export const COMPANY_DATA_LABELS: Record<string, any> = {
   registrant: 'Registrant',
   givenName: 'Given name',

--- a/lib/utils/JSONStorage.ts
+++ b/lib/utils/JSONStorage.ts
@@ -29,7 +29,7 @@ export const JSONLocalStorage = (() => {
   if (typeof window !== 'undefined') {
     return new JSONStorage(localStorage);
   } else {
-    return undefined;
+    return {} as JSONStorage; // Fails if used in server-side runtime
   }
 })();
 
@@ -37,6 +37,6 @@ export const JSONSessionStorage = (() => {
   if (typeof window !== 'undefined') {
     return new JSONStorage(sessionStorage);
   } else {
-    return undefined;
+    return {} as JSONStorage; // Fails if used in server-side runtime
   }
 })();

--- a/lib/utils/JSONStorage.ts
+++ b/lib/utils/JSONStorage.ts
@@ -1,0 +1,42 @@
+class JSONStorage {
+  driver: Storage;
+
+  constructor(driver: Storage) {
+    this.driver = driver;
+  }
+
+  get(key: string) {
+    const value = this.driver.getItem(key);
+    return value ? JSON.parse(value) : null;
+  }
+  set(key: string, value: any) {
+    this.driver.setItem(key, JSON.stringify(value));
+  }
+  clear() {
+    this.driver.clear();
+  }
+  has(key: string): boolean {
+    return !!this.driver.getItem(key);
+  }
+  remove(key: string) {
+    this.driver.removeItem(key);
+  }
+}
+
+// class instance invokement inside self-executing function
+// this way window object should be defined, once client side code is loaded
+export const JSONLocalStorage = (() => {
+  if (typeof window !== 'undefined') {
+    return new JSONStorage(localStorage);
+  } else {
+    return undefined;
+  }
+})();
+
+export const JSONSessionStorage = (() => {
+  if (typeof window !== 'undefined') {
+    return new JSONStorage(sessionStorage);
+  } else {
+    return undefined;
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "date-fns": "^2.29.3",
         "eslint": "8.34.0",
         "eslint-config-next": "13.1.6",
-        "js-cookie": "^3.0.1",
         "jwt-decode": "^3.1.2",
         "lodash.get": "^4.4.2",
         "lodash.merge": "^4.6.2",
@@ -4373,14 +4372,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/js-sdsl": {
@@ -10690,11 +10681,6 @@
           }
         }
       }
-    },
-    "js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-sdsl": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "date-fns": "^2.29.3",
     "eslint": "8.34.0",
     "eslint-config-next": "13.1.6",
-    "js-cookie": "^3.0.1",
     "jwt-decode": "^3.1.2",
     "lodash.get": "^4.4.2",
     "lodash.merge": "^4.6.2",

--- a/pages/auth.page.tsx
+++ b/pages/auth.page.tsx
@@ -3,7 +3,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { Paragraph } from 'suomifi-ui-components';
 import { AuthProvider } from '@/types';
 import api from '@/lib/api';
+import { LOCAL_STORAGE_REDIRECT_KEY } from '@/lib/constants';
 import { generateAppContextHash } from '@/lib/utils';
+import { JSONLocalStorage } from '@/lib/utils/JSONStorage';
 import { useAuth } from '@/context/auth-context';
 import Alert from '@/components/ui/alert';
 import Loading from '@/components/ui/loading';
@@ -23,7 +25,7 @@ export default function AuthPage() {
       });
 
       logIn(loggedInState);
-      const redirectPath = localStorage.getItem('redirectPath');
+      const redirectPath = JSONLocalStorage?.get(LOCAL_STORAGE_REDIRECT_KEY);
       router.push(redirectPath || '/');
     } catch (error: any) {
       console.log(error);

--- a/pages/auth.page.tsx
+++ b/pages/auth.page.tsx
@@ -25,7 +25,7 @@ export default function AuthPage() {
       });
 
       logIn(loggedInState);
-      const redirectPath = JSONLocalStorage?.get(LOCAL_STORAGE_REDIRECT_KEY);
+      const redirectPath = JSONLocalStorage.get(LOCAL_STORAGE_REDIRECT_KEY);
       router.push(redirectPath || '/');
     } catch (error: any) {
       console.log(error);


### PR DESCRIPTION
- js-cookie poistettu, käytetään localStoragea niin kuin ennenkin.
- Käytetään aikaisempaa JSONStorage classia. Noiden storejen invokement itse suoriutuvissa funkkareissa, jotta window object on defined (tästä ei 100% varmuutta, että toimii joka ikinen kerta, omissa testeissä pelitti kyllä?)
- apiClient / auth context -> token expiration tsekit, logataan käyttäjä ulos jos autorisoidut fetchit heittää erroria ja jos token vanhentunut
- liittyviä parannuksia (constit, helper funkkaria)