### PR TITLE
Referrer testausta

### DIFF
--- a/context/referrer-context.tsx
+++ b/context/referrer-context.tsx
@@ -1,0 +1,58 @@
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+interface ReferrerContextProps {
+  referrer: string;
+}
+
+interface ReferrerProviderProps {
+  children: ReactNode;
+}
+
+const ReferrerContext = createContext<ReferrerContextProps | undefined>(
+  undefined
+);
+
+function ReferrerProvider({ children }: ReferrerProviderProps) {
+  const [referrer, setReferrer] = useState('');
+
+  useEffect(() => {
+    if (document.referrer) {
+      // alternative, does not work when in local dev, since all are "localhost"
+      /* const domain = new URL(document.referrer).hostname;
+      console.log(domain); */
+
+      const url = document.referrer;
+      const parsed = url.match(/:\/\/(.[^/]+)/); // try to get domain only, in local localhost:port
+      const ref = parsed ? parsed[1] : '';
+      setReferrer(ref);
+    }
+  }, []);
+
+  return (
+    <ReferrerContext.Provider
+      value={{
+        referrer,
+      }}
+    >
+      {children}
+    </ReferrerContext.Provider>
+  );
+}
+
+function useReferrerContext() {
+  const context = useContext(ReferrerContext);
+
+  if (context === undefined) {
+    throw new Error('useRefererContext must be used within a RefererProvider');
+  }
+
+  return context;
+}
+
+export { ReferrerContext, ReferrerProvider, useReferrerContext };

--- a/lib/api/endpoints/index.ts
+++ b/lib/api/endpoints/index.ts
@@ -15,3 +15,12 @@ export const TESTBED_API_BASE_URL = process.env.NEXT_PUBLIC_TESTBED_API_BASE_URL
 export const CODESETS_BASE_URL = process.env.NEXT_PUBLIC_CODESETS_BASE_URL
   ? removeTrailingSlash(process.env.NEXT_PUBLIC_CODESETS_BASE_URL)
   : 'http://localhost:3166';
+
+export const ATOF_BASE_URL = process.env.NEXT_PUBLIC_ATOF_BASE_URL
+  ? removeTrailingSlash(process.env.NEXT_PUBLIC_ATOF_BASE_URL)
+  : 'http://localhost:3004';
+
+export const EXT_REGISTRATION_SERVICE_URL = process.env
+  .NEXT_PUBLIC_EXT_REGISTRATION_SERVICE_URL
+  ? removeTrailingSlash(process.env.NEXT_PUBLIC_EXT_REGISTRATION_SERVICE_URL)
+  : 'http://localhost:3001';

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -78,3 +78,12 @@ export function getUserIdentifier() {
   const { sub }: { sub: string | undefined } = jwt_decode(token);
   return sub;
 }
+
+export function parseReferrer(url: string) {
+  // alternative, does not work when in local dev, since all are "localhost"
+  // const domain = new URL(url).hostname;
+  // console.log(domain);
+  const parsed = url.match(/:\/\/(.[^/]+)/); // try to get domain only, in local localhost:port
+  const referrer = parsed ? parsed[1] : '';
+  return referrer;
+}

--- a/pages/profile/index.page.tsx
+++ b/pages/profile/index.page.tsx
@@ -1,11 +1,16 @@
 import { useState } from 'react';
-import { Button, Text, TextInput } from 'suomifi-ui-components';
+import { Button, InlineAlert, Text, TextInput } from 'suomifi-ui-components';
 import api from '@/lib/api';
+import {
+  ReferrerProvider,
+  useReferrerContext,
+} from '@/context/referrer-context';
 import Page from '@/components/layout/page';
 import CustomHeading from '@/components/ui/custom-heading';
 
 export default function ProfilePage() {
   const [isLoading, setLoading] = useState(false);
+  const { referrer } = useReferrerContext();
 
   const loginHandler = () => {
     setLoading(true);
@@ -19,6 +24,9 @@ export default function ProfilePage() {
           Create your profile
         </CustomHeading>
         <div className="flex flex-col mt-8 gap-6">
+          {referrer === 'localhost:3004' && (
+            <InlineAlert>You arrived from Access to Finland app!</InlineAlert>
+          )}
           <Text>
             Choose which service to use to log in to Living in Finland.
           </Text>
@@ -43,3 +51,5 @@ export default function ProfilePage() {
     </Page>
   );
 }
+
+ProfilePage.provider = ReferrerProvider;

--- a/pages/profile/index.page.tsx
+++ b/pages/profile/index.page.tsx
@@ -10,11 +10,11 @@ import CustomHeading from '@/components/ui/custom-heading';
 
 export default function ProfilePage() {
   const [isLoading, setLoading] = useState(false);
-  const { referrer } = useReferrerContext();
+  const { referrerSettings } = useReferrerContext();
 
   const loginHandler = () => {
     setLoading(true);
-    api.auth.directToAuthGwLogin();
+    api.auth.directToAuthGwLogin('/profile');
   };
 
   return (
@@ -24,8 +24,18 @@ export default function ProfilePage() {
           Create your profile
         </CustomHeading>
         <div className="flex flex-col mt-8 gap-6">
-          {referrer === 'localhost:3004' && (
-            <InlineAlert>You arrived from Access to Finland app!</InlineAlert>
+          {referrerSettings && (
+            <InlineAlert>
+              <div className="flex flex-col gap-3 items-start">
+                <Text>{referrerSettings.text}</Text>
+                <a
+                  href={referrerSettings.redirectUrl}
+                  className="underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+                >
+                  {referrerSettings.redirectText}
+                </a>
+              </div>
+            </InlineAlert>
           )}
           <Text>
             Choose which service to use to log in to Living in Finland.


### PR DESCRIPTION
Todella simppeli testi, miten tuota referrer kikkailua voisi toteuttaa.

- Jos kyseessä olisi profiilikikkailuista, niin jalostaisin tätä eteenpäin niin, että referrer kontekstin sijaan tehtäisiin jokin profile-settings-context tms, missä tarkistetaan referrer tieto.
- Meillä olisi setti ennalta sovittuja asetuksia per palvelu (mitä fieldejä näytetään, disaboidaan, enabloidaan, yms., vaikka json filuja).
- Referrer tiedon peruusteella (domain), palautellaan oikeat asetukset profiilisivulle/sivuille. Sen perusteella piilotellaan / näytetään täytettäviä fieldejä. Jos domainille ei löydy asetuksia, kaikki toimii oletusasetuksilla -> kaikki enabloituna / näkyvillä.
- Asetukset voisi pitää sisällään myös esimerkiksi redirect-urleja, jotta käyttäjä voitaisiin ohjata takaisin haluttuun paikkaan. Nämä tosin täytyisi jotenkin rajata ja lyödä lukkoon, sillä menee aika nopeasti villiksi länneksi, jos jokaiselle palvelulle on kourallinen omia asetuksiaan.
- Tätä varten täytyy varmistaa, että riippumatta asetuksista productizereille lähtee aina "täysi" setti, eli default valuet missä kaikki tyhjää / nullia (jos fieldejä piilotellaan, niitä ei rekisteröidä ollenkaan formissa, jolloin lähtisi vajaata dataa matkaan -> täytetään puuttuvat tyhjillä defaulteilla)

Sellainen positiivinen havainto tuosta referrer-tiedosta, että tuo vaikuttaisi persistoituvan selaimen/tabin sessiossa, eli sen persistoitumisesta ei välttämättä tarvitsisi huolehtia itse ollenkaan.

Tässä nopeasti kikkailtuna testasin atof-sovelluksella, vaihdoin sen porttia ja lisäsin linkin menemään VF appsin profiili-sivulle.

Ei tosiaan mergattavaksi, enemmänkin keskustelua herättämään. To be closed.